### PR TITLE
Update API_TranslateText.md

### DIFF
--- a/doc_source/API_TranslateText.md
+++ b/doc_source/API_TranslateText.md
@@ -146,6 +146,11 @@ HTTP Status Code: 400
 Amazon Translate does not support translation from the language of the source text into the requested target language\. For more information, see [Exception handling](how-it-works.md#how-to-error-msg)\.   
 HTTP Status Code: 400
 
+ ** ValidationException **   
+An error occurred (ValidationException) when calling the TranslateText operation: Autodetect language is not supported\.   
+HTTP Status Code: 400   
+This error occurs if you have set 'SourceLanguageCode' to 'auto' in a region in which Amazon Comprehend is not available\. For example, if you are using Amazon Translate in eu\-west\-3 \- Paris where Amazon Comprehend is not yet available \(as of June 2022\) the request will fail with this error message\.   
+
 ## See Also<a name="API_TranslateText_SeeAlso"></a>
 
 For more information about using this API in one of the language\-specific AWS SDKs, see the following:


### PR DESCRIPTION
Added an under-documented error case

*Issue #, if available:* When following the instructions in the Translate documentation there is an un(der)documented error case where Translate attempts to call Comprehend in the same region, but if Comprehend is not in the region it fails. As it stands now, the error simply states "autodetect is not supported" which would appear to be in conflict with the documentation. (Alternatively the error message could say it's not supported because Comprehend is not available in the target region, but this seemed quicker).

*Description of changes:* I added the error and the cause in the page.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
